### PR TITLE
create a directory before model save

### DIFF
--- a/training_supervised_policy.py
+++ b/training_supervised_policy.py
@@ -10,6 +10,7 @@ from tensorflow.keras import regularizers
 
 import matplotlib.pylab as plt
 import utils
+import os
 
 def perform_training(initializing, netname, numlayers = 6,
                      inpath = "SolvedLevels/", epochs = 3,
@@ -134,7 +135,11 @@ def perform_training(initializing, netname, numlayers = 6,
     plt.ylabel('Accuracy')
     plt.show()
     
+    
     model_json = model.to_json()
+    dir = os.getcwd()+'/networks'
+    if not os.path.exists(dir):
+        os.mkdir(dir)
     with open("networks/policy_" + netname + ".json", "w") as json_file:
         json_file.write(model_json)
         


### PR DESCRIPTION
If the networks folder hadn't been created before, the run would crash while trying to save the model.